### PR TITLE
Some error handing, and Support windows

### DIFF
--- a/gomain.go
+++ b/gomain.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"github.com/tj/go-spin"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -29,8 +30,9 @@ const (
 )
 
 var (
-	endpoint = "https://domainr.com/api/json/search?q=%s&client_id=gomain"
-	out      = os.Stdout
+	endpoint           = "https://domainr.com/api/json/search?q=%s&client_id=gomain"
+	out      io.Writer = os.Stdout
+	box                = spin.Box1
 )
 
 type query struct {
@@ -62,7 +64,7 @@ func main() {
 
 	go tock(tick)
 	req, err := http.Get(fmt.Sprintf(endpoint, argv[0]))
-	fmt.Printf("\n")
+	fmt.Printf("\r")
 	tick.Stop()
 
 	if err != nil {
@@ -94,7 +96,7 @@ func main() {
 
 func tock(t *time.Ticker) {
 	s := spin.New()
-	s.Set(spin.Box1)
+	s.Set(box)
 
 	for _ = range t.C {
 		fmt.Fprintf(out, "\r%s", s.Next())

--- a/gomain.go
+++ b/gomain.go
@@ -30,6 +30,7 @@ const (
 
 var (
 	endpoint = "https://domainr.com/api/json/search?q=%s&client_id=gomain"
+	out      = os.Stdout
 )
 
 type query struct {
@@ -53,8 +54,8 @@ func main() {
 	argv := flag.Args()
 
 	if len(argv) < 1 {
-		fmt.Printf("Domain required.\n")
-		return
+		fmt.Fprintf(os.Stderr, "Domain required.\n")
+		os.Exit(1)
 	}
 
 	tick := time.NewTicker(50 * time.Millisecond)
@@ -65,24 +66,28 @@ func main() {
 	tick.Stop()
 
 	if err != nil {
-		fmt.Printf("Server could not be reached.\n")
-		return
+		fmt.Fprintf(os.Stderr, "Server could not be reached.\n")
+		os.Exit(1)
+	}
+
+	body, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Invalid response from server.\n")
+		os.Exit(1)
 	}
 
 	var query query
-
-	body, _ := ioutil.ReadAll(req.Body)
 
 	json.Unmarshal(body, &query)
 
 	for _, dom := range query.Results {
 		switch dom.Availability {
 		case "available":
-			fmt.Printf("%sA %s%s\n", green, normal, dom.Domain)
+			fmt.Fprintf(out, "%sA %s%s\n", green, normal, dom.Domain)
 		case "maybe", "unknown":
-			fmt.Printf("%sM %s%s\n", yellow, normal, dom.Domain)
+			fmt.Fprintf(out, "%sM %s%s\n", yellow, normal, dom.Domain)
 		default:
-			fmt.Printf("%sU %s%s\n", gray, normal, dom.Domain)
+			fmt.Fprintf(out, "%sU %s%s\n", gray, normal, dom.Domain)
 		}
 	}
 }
@@ -92,6 +97,6 @@ func tock(t *time.Ticker) {
 	s.Set(spin.Box1)
 
 	for _ = range t.C {
-		fmt.Printf("\r%s", s.Next())
+		fmt.Fprintf(out, "\r%s", s.Next())
 	}
 }

--- a/gomain_windows.go
+++ b/gomain_windows.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"github.com/mattn/go-colorable"
+	"github.com/tj/go-spin"
+)
+
+func init() {
+	out = colorable.NewColorableStdout()
+	box = spin.Spin1
+}


### PR DESCRIPTION
* exit with non-zero value
* write error message to stderr instead of stdout
* use `out`, `box` because it will be used for windows support.
* added `gomain_windows.go` that do windows hacks.



